### PR TITLE
I've updated the module for Foundry VTT V12 compatibility.

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,8 +5,8 @@
     "version": "This is auto replaced",
     "library": "false",
     "manifestPlusVersion": "1.2.0",
-    "minimumCoreVersion": "9",
-    "compatibleCoreVersion": "9.249",
+    "minimumCoreVersion": "12",
+    "compatibleCoreVersion": "12",
     "author": "Vanish",
     "authors": [
         {


### PR DESCRIPTION
Here's what I did:
- I updated the module.json to set minimumCoreVersion and compatibleCoreVersion to 12.
- I verified the TinyMCE customization approach against V12 documentation. It seems TinyMCE is now deprecated in V12 and will be removed in a future version, so the way this module customizes the text editor will need to be revisited then.
- I assumed the JournalSheet CSS selectors remain valid based on the available documentation.

I recommend you do some further manual testing to ensure all features function as expected in V12.